### PR TITLE
Zone.strong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### Pub version 0.14.0+7
+  * Update to work with strong-mode clean Zone API.
+
 #### Pub version 0.14.0+6
   * Fixed bug whereby too much code was pruned in 0.14.0+5
 

--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -156,8 +156,8 @@ JsObject bindableToJsObject(Bindable bindable) {
   if (bindable is _JsBindable) return bindable._js;
 
   var zone = Zone.current;
-  inZone(f) => zone.bindCallback(f, runGuarded: false);
-  inZoneUnary(f) => zone.bindUnaryCallback(f, runGuarded: false);
+  inZone(f) => zone.bindCallback(f);
+  inZoneUnary(f) => zone.bindUnaryCallback(f);
 
   return new JsObject.jsify({
     'open':

--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -156,8 +156,14 @@ JsObject bindableToJsObject(Bindable bindable) {
   if (bindable is _JsBindable) return bindable._js;
 
   var zone = Zone.current;
-  inZone(f) => zone.bindCallback(f);
-  inZoneUnary(f) => zone.bindUnaryCallback(f);
+  inZone<R>(R f()) {
+    var registered = zone.registerCallback(f);
+    return () => zone.run(registered);
+  }
+  inZoneUnary<R, T>(R f(T x)) {
+    var registered = zone.registerUnaryCallback(f);
+    return (x) => zone.runUnary(registered, x);
+  }
 
   return new JsObject.jsify({
     'open':

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: template_binding
-version: 0.14.0+8
+version: 0.14.0+7
 author: Polymer.dart Team <web-ui-dev@dartlang.org>
 description: >
   Extends the capabilities of the HTML Template Element by enabling it to

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: template_binding
-version: 0.14.0+7
+version: 0.14.0+8
 author: Polymer.dart Team <web-ui-dev@dartlang.org>
 description: >
   Extends the capabilities of the HTML Template Element by enabling it to
@@ -13,4 +13,4 @@ dev_dependencies:
   unittest: ">=0.10.0 <0.12.0"
   browser: ">=0.10.0 <0.11.0"
 environment:
-  sdk: ">=1.8.0 <2.0.0"
+  sdk: ">=1.25.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: template_binding
-version: 0.14.0+6
+version: 0.14.0+7
 author: Polymer.dart Team <web-ui-dev@dartlang.org>
 description: >
   Extends the capabilities of the HTML Template Element by enabling it to

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,4 +13,4 @@ dev_dependencies:
   unittest: ">=0.10.0 <0.12.0"
   browser: ">=0.10.0 <0.11.0"
 environment:
-  sdk: ">=1.25.0 <2.0.0"
+  sdk: ">=1.8.0 <2.0.0"


### PR DESCRIPTION
The `dart:async` zone API is in the process of becoming strong-mode clean.
This patch fixes a breakage introduced by this change.

Note that `false` was the default anyway. So this change has no impact on the behavior.